### PR TITLE
Replace shuf with rand()

### DIFF
--- a/kitty_mode.sh
+++ b/kitty_mode.sh
@@ -4,7 +4,7 @@
 
 kitty_mode() {
 	clear "$@"												# clear with whatever arguments are passed
-	cat "./ascii_arts/$(ls ./ascii_arts | shuf -n 1)"       # print the ascii art
+	cat "./ascii_arts/$(ls ./ascii_arts | awk 'BEGIN{srand();}{a[NR]=$0}END{print a[int(rand()*NR)+1]}')"       # print the ascii art
 	printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' _ # fill line with `_`
 }
 


### PR DESCRIPTION
shuf isn't available natively on macOS. Use rand() to randomly select a file instead